### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Managed by CODEOWNERS rollout
+* @kiddom/pr-size-watcher-codeowners


### PR DESCRIPTION
Create repo codeowners team, add top engineering contributors, and point CODEOWNERS to the team.